### PR TITLE
feat: extra collateral rewards

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -25,7 +25,7 @@ type = "connections"
 [[vm]]
 cpu_kind = "shared"
 cpus = 1
-memory_mb = 256
+memory_mb = 512
 
 [[http_service.checks]]
 grace_period = "10s"

--- a/src/apy/coinshift/apy.ts
+++ b/src/apy/coinshift/apy.ts
@@ -33,9 +33,8 @@ const getAPY: APYHandler = async network => {
   if (!tokens || !("csUSDL" in tokens)) return {};
 
   const res = await axios.post<Response>(URL, PAYLOAD);
-  const { state, asset } = res?.data.data?.vault || {};
+  const { state } = res?.data.data?.vault || {};
   const { netApy = 0 } = state || {};
-  const { apr = 0 } = asset?.yield || {};
 
   const result: APYResult = {
     [tokens.csUSDL]: {
@@ -47,7 +46,7 @@ const getAPY: APYHandler = async network => {
           reward: tokens.csUSDL,
           symbol: "csUSDL",
           protocol: PROTOCOL,
-          value: Number(netApy + apr) * 100,
+          value: Number(netApy) * 100,
         },
       ],
     },

--- a/src/apy/coinshift/apy.ts
+++ b/src/apy/coinshift/apy.ts
@@ -43,7 +43,7 @@ const getAPY: APYHandler = async network => {
 
       apys: [
         {
-          reward: tokens.csUSDL,
+          address: tokens.csUSDL,
           symbol: "csUSDL",
           protocol: PROTOCOL,
           value: Number(netApy) * 100,

--- a/src/apy/constant/apy.ts
+++ b/src/apy/constant/apy.ts
@@ -15,7 +15,7 @@ const getAPY: APYHandler = async network => {
 
       apys: [
         {
-          reward: address,
+          address: address,
           symbol: info.symbol,
           protocol: PROTOCOL,
           value: info.apy,

--- a/src/apy/constant/constants.ts
+++ b/src/apy/constant/constants.ts
@@ -4,7 +4,7 @@ import type { NetworkType } from "../../utils";
 
 const ezETH = {
   symbol: "ezETH",
-  apy: 3.37,
+  apy: 3.79,
 };
 const rsETH = {
   symbol: "rsETH",
@@ -12,11 +12,11 @@ const rsETH = {
 };
 const weETH = {
   symbol: "weETH",
-  apy: 3.4,
+  apy: 3.7,
 };
 const rswETH = {
   symbol: "rswETH",
-  apy: 2.76,
+  apy: 2.77,
 };
 const pufETH = {
   symbol: "pufETH",

--- a/src/apy/constants.ts
+++ b/src/apy/constants.ts
@@ -3,7 +3,7 @@ import type { Address } from "viem";
 import type { NetworkType } from "../utils";
 
 export interface Apy {
-  reward: Address;
+  address: Address;
   symbol: string;
   protocol: string;
 

--- a/src/apy/curve/apy.ts
+++ b/src/apy/curve/apy.ts
@@ -146,7 +146,7 @@ const getAPY: APYHandler = async network => {
 
         apys: [
           {
-            reward: pool.lpTokenAddress,
+            address: pool.lpTokenAddress,
             symbol,
             protocol: PROTOCOL,
             value: baseAPY,

--- a/src/apy/ethena/apy.ts
+++ b/src/apy/ethena/apy.ts
@@ -27,7 +27,7 @@ const getAPY: APYHandler = async network => {
 
       apys: [
         {
-          reward: tokens.sUSDe,
+          address: tokens.sUSDe,
           symbol: "sUSDe",
           protocol: PROTOCOL,
           value: Number(rate) * 100,

--- a/src/apy/lido/apy.ts
+++ b/src/apy/lido/apy.ts
@@ -41,7 +41,7 @@ const getAPY: APYHandler = async network => {
 
         apys: [
           {
-            reward: address,
+            address: address,
             symbol: symbol,
             protocol: PROTOCOL,
             value: smaApr,

--- a/src/apy/llama/apy.ts
+++ b/src/apy/llama/apy.ts
@@ -43,7 +43,7 @@ const getAPY: APYHandler = async network => {
 
         apys: [
           {
-            reward: address,
+            address: address,
             symbol: p.symbol,
             protocol: PROTOCOL,
             value: pool.apy || 0,

--- a/src/apy/sky/apy.ts
+++ b/src/apy/sky/apy.ts
@@ -29,7 +29,7 @@ const getAPY: APYHandler = async network => {
 
       apys: [
         {
-          reward: tokens.sUSDS,
+          address: tokens.sUSDS,
           symbol: "sUSDS",
           protocol: PROTOCOL,
           value: Number(savingsRate) * 100,
@@ -41,7 +41,7 @@ const getAPY: APYHandler = async network => {
       symbol: "stkUSDS",
       apys: [
         {
-          reward: tokens.stkUSDS,
+          address: tokens.stkUSDS,
           symbol: "stkUSDS",
           protocol: PROTOCOL,
           value: Number(farmRate) * 100,

--- a/src/apy/sonic/apy.ts
+++ b/src/apy/sonic/apy.ts
@@ -27,7 +27,7 @@ const getAPY: APYHandler = async network => {
 
       apys: [
         {
-          reward: tokens.stS,
+          address: tokens.stS,
           symbol: "stS",
           protocol: PROTOCOL,
           value: Number(stakingApr) * 100,

--- a/src/apy/treehouse/apy.ts
+++ b/src/apy/treehouse/apy.ts
@@ -26,7 +26,7 @@ const getAPY: APYHandler = async network => {
 
       apys: [
         {
-          reward: tokens.tETH,
+          address: tokens.tETH,
           symbol: "tETH",
           protocol: PROTOCOL,
           value: rate,

--- a/src/apy/yearn/apy.ts
+++ b/src/apy/yearn/apy.ts
@@ -41,7 +41,7 @@ const getAPY: APYHandler = async network => {
 
         apys: [
           {
-            reward: d.address,
+            address: d.address,
             symbol,
             protocol: PROTOCOL,
             value: Number(netApy) * 100,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,4 +1,3 @@
-import e from "cors";
 import moment from "moment";
 import type { Address } from "viem";
 
@@ -20,6 +19,10 @@ import type { PointsResult } from "./points";
 import { getPoints } from "./points";
 import type { PoolPointsResult } from "./poolRewards";
 import { getPoolPoints } from "./poolRewards";
+import type { TokenExtraCollateralAPYResult } from "./tokenExtraCollateralAPY";
+import { getTokenExtraCollateralAPY } from "./tokenExtraCollateralAPY";
+import type { TokenExtraCollateralPointsResult } from "./tokenExtraCollateralPoints";
+import { getTokenExtraCollateralPoints } from "./tokenExtraCollateralPoints";
 import type { TokenExtraRewardsResult } from "./tokenExtraRewards";
 import { getTokenExtraRewards } from "./tokenExtraRewards";
 import type { NetworkType } from "./utils";
@@ -30,24 +33,169 @@ type TokenDetails = TokenAPY<ApyDetails>;
 
 interface NetworkState {
   tokenApyList: Record<Address, TokenDetails>;
+  tokenExtraCollateralAPY: TokenExtraCollateralAPYResult;
   tokenExtraRewards: TokenExtraRewardsResult;
   tokenPointsList: PointsResult;
+  tokenExtraCollateralPoints: TokenExtraCollateralPointsResult;
 
   poolPointsList: PoolPointsResult;
 
   gear: GearAPY;
 }
 
-function log(
-  network: NetworkType,
-  allProtocolAPYs: Array<PromiseSettledResult<APYResult>>,
-  pointsList: PromiseSettledResult<PointsResult>,
-  tokenExtraRewards: PromiseSettledResult<TokenExtraRewardsResult>,
+export class Fetcher {
+  public cache: Record<number, NetworkState>;
 
-  poolPointsList: PromiseSettledResult<PoolPointsResult>,
+  constructor() {
+    this.cache = {};
+  }
 
-  gearAPY: PromiseSettledResult<GearAPY>,
-) {
+  private async getNetworkState(network: NetworkType): Promise<NetworkState> {
+    const [
+      gearAPY,
+      points,
+      poolPoints,
+      extraRewards,
+      extraCollateralAPY,
+      extraCollateralPoints,
+
+      ...allProtocolAPYs
+    ] = await Promise.allSettled([
+      getGearAPY(network),
+
+      getPoints(network),
+
+      getPoolPoints(network),
+
+      getTokenExtraRewards(network),
+
+      getTokenExtraCollateralAPY(network),
+
+      getTokenExtraCollateralPoints(network),
+
+      getAPYCurve(network),
+      getAPYEthena(network),
+      getAPYLama(network),
+      getAPYLido(network),
+      getAPYSky(network),
+      getAPYYearn(network),
+      getAPYTreehouse(network),
+      getAPYConstant(network),
+      getAPYSonic(network),
+      getAPYCoinshift(network),
+    ]);
+    log({
+      network,
+      allProtocolAPYs,
+      pointsList: points,
+      tokenExtraRewards: extraRewards,
+      extraCollateralAPY,
+      extraCollateralPoints,
+
+      poolPointsList: poolPoints,
+
+      gearAPY,
+    });
+
+    const time = moment().utc().format();
+
+    const tokenApyList = allProtocolAPYs.reduce<Record<Address, TokenDetails>>(
+      (acc, apyRes) => {
+        if (apyRes.status === "fulfilled") {
+          Object.entries(apyRes.value).forEach(([addr, tokenAPY]) => {
+            const address = addr.toLowerCase() as Address;
+
+            const apyList = tokenAPY?.apys.map(
+              ({ address, ...rest }): ApyDetails => ({
+                ...rest,
+                lastUpdated: time,
+                address: address.toLowerCase() as Address,
+              }),
+            );
+
+            acc[address] = {
+              ...tokenAPY,
+              address,
+              apys: [...(acc[address]?.apys || []), ...apyList],
+            };
+          });
+        }
+
+        return acc;
+      },
+      {},
+    );
+
+    const tokenPointsList = points.status === "fulfilled" ? points.value : {};
+
+    const poolPointsList =
+      poolPoints.status === "fulfilled" ? poolPoints.value : {};
+
+    const tokenExtraRewards =
+      extraRewards.status === "fulfilled" ? extraRewards.value : {};
+
+    const tokenExtraCollateralAPY =
+      extraCollateralAPY.status === "fulfilled" ? extraCollateralAPY.value : {};
+
+    const tokenExtraCollateralPoints =
+      extraCollateralPoints.status === "fulfilled"
+        ? extraCollateralPoints.value
+        : {};
+
+    return {
+      gear:
+        gearAPY.status === "fulfilled"
+          ? gearAPY.value
+          : { base: 0, crv: 0, gear: 0 },
+      tokenApyList,
+      tokenPointsList,
+      poolPointsList,
+      tokenExtraRewards,
+      tokenExtraCollateralAPY,
+      tokenExtraCollateralPoints,
+    };
+  }
+
+  async run() {
+    console.log("updating fetcher");
+    for (const network of Object.values(supportedChains)) {
+      const chainId = getChainId(network);
+      const state = await this.getNetworkState(network as NetworkType);
+      this.cache[chainId] = state;
+    }
+  }
+
+  async loop() {
+    void this.run();
+    setInterval(this.run.bind(this), 60 * 60 * 1000); // 1 hr
+  }
+}
+
+interface LogProps {
+  network: NetworkType;
+  allProtocolAPYs: Array<PromiseSettledResult<APYResult>>;
+  pointsList: PromiseSettledResult<PointsResult>;
+  tokenExtraRewards: PromiseSettledResult<TokenExtraRewardsResult>;
+  extraCollateralAPY: PromiseSettledResult<TokenExtraCollateralAPYResult>;
+  extraCollateralPoints: PromiseSettledResult<TokenExtraCollateralPointsResult>;
+
+  poolPointsList: PromiseSettledResult<PoolPointsResult>;
+
+  gearAPY: PromiseSettledResult<GearAPY>;
+}
+
+function log({
+  network,
+  allProtocolAPYs,
+  pointsList,
+  tokenExtraRewards,
+  extraCollateralAPY,
+  extraCollateralPoints,
+
+  poolPointsList,
+
+  gearAPY,
+}: LogProps) {
   const list = allProtocolAPYs.map(apyRes => {
     const entries =
       apyRes.status === "fulfilled" ? Object.entries(apyRes.value) : [];
@@ -121,99 +269,39 @@ function log(
   } else {
     console.log(`\nPoints error: ${poolPointsList.reason}`);
   }
-}
 
-export class Fetcher {
-  public cache: Record<number, NetworkState>;
+  if (extraCollateralAPY.status === "fulfilled") {
+    const extraCollateral = Object.values(extraCollateralAPY.value);
 
-  constructor() {
-    this.cache = {};
-  }
-
-  private async getNetworkState(network: NetworkType): Promise<NetworkState> {
-    const [gearAPY, points, poolPoints, extraRewards, ...allProtocolAPYs] =
-      await Promise.allSettled([
-        getGearAPY(network),
-
-        getPoints(network),
-
-        getPoolPoints(network),
-
-        getTokenExtraRewards(network),
-
-        getAPYCurve(network),
-        getAPYEthena(network),
-        getAPYLama(network),
-        getAPYLido(network),
-        getAPYSky(network),
-        getAPYYearn(network),
-        getAPYTreehouse(network),
-        getAPYConstant(network),
-        getAPYSonic(network),
-        getAPYCoinshift(network),
-      ]);
-    log(network, allProtocolAPYs, points, extraRewards, poolPoints, gearAPY);
-
-    const time = moment().utc().format();
-
-    const tokenApyList = allProtocolAPYs.reduce<Record<Address, TokenDetails>>(
-      (acc, apyRes) => {
-        if (apyRes.status === "fulfilled") {
-          Object.entries(apyRes.value).forEach(([addr, tokenAPY]) => {
-            const address = addr.toLowerCase() as Address;
-
-            const apyList = tokenAPY?.apys.map(
-              ({ reward, ...rest }): ApyDetails => ({
-                ...rest,
-                lastUpdated: time,
-                reward: reward.toLowerCase() as Address,
-              }),
-            );
-
-            acc[address] = {
-              ...tokenAPY,
-              address,
-              apys: [...(acc[address]?.apys || []), ...apyList],
-            };
-          });
-        }
-
-        return acc;
-      },
-      {},
-    );
-
-    const tokenPointsList = points.status === "fulfilled" ? points.value : {};
-
-    const poolPointsList =
-      poolPoints.status === "fulfilled" ? poolPoints.value : {};
-
-    const tokenExtraRewards =
-      extraRewards.status === "fulfilled" ? extraRewards.value : {};
-
-    return {
-      gear:
-        gearAPY.status === "fulfilled"
-          ? gearAPY.value
-          : { base: 0, crv: 0, gear: 0 },
-      tokenApyList,
-      tokenPointsList,
-      poolPointsList,
-      tokenExtraRewards,
-    };
-  }
-
-  async run() {
-    console.log("updating fetcher");
-    for (const network of Object.values(supportedChains)) {
-      const chainId = getChainId(network);
-      const state = await this.getNetworkState(network as NetworkType);
-      this.cache[chainId] = state;
+    if (extraCollateral.length > 0) {
+      console.log(
+        `\nFetched extra collateral apy for ${extraCollateral
+          .map(p => p.map(t => `${t.pool}: ${t.symbol}`))
+          .flat(1)
+          .join(", ")} for ${network}`,
+      );
+    } else {
+      console.log(`\nFetched no extra collateral apy for ${network}`);
     }
+  } else {
+    console.log(`\nExtra collateral apy error: ${extraCollateralAPY.reason}`);
   }
 
-  async loop() {
-    void this.run();
-    setInterval(this.run.bind(this), 60 * 60 * 1000); // 1 hr
+  if (extraCollateralPoints.status === "fulfilled") {
+    const extraPoints = Object.values(extraCollateralPoints.value);
+
+    if (extraPoints.length > 0) {
+      console.log(
+        `\nFetched extra collateral points for ${extraPoints
+          .map(p => p.symbol)
+          .join(", ")} for ${network}`,
+      );
+    } else {
+      console.log(`\nFetched no extra collateral points for ${network}`);
+    }
+  } else {
+    console.log(
+      `\eExtra collateral points error: ${extraCollateralPoints.reason}`,
+    );
   }
 }

--- a/src/points/constants.ts
+++ b/src/points/constants.ts
@@ -45,7 +45,7 @@ interface DebtReward extends PointsReward {
 type CommonReward<CM extends DebtReward["cm"] | undefined> =
   CM extends undefined ? PointsReward : DebtReward;
 
-const REWARDS_BASE_INFO = {
+export const REWARDS_BASE_INFO = {
   eigenlayer: (multiplier: PointsReward["multiplier"]): PointsReward => ({
     name: "Eigenlayer",
     units: "points",

--- a/src/tokenExtraCollateralAPY/constants.ts
+++ b/src/tokenExtraCollateralAPY/constants.ts
@@ -1,0 +1,33 @@
+import type { Address } from "viem";
+
+import type { Apy } from "../apy";
+import type { NetworkType } from "../utils";
+
+export interface ExtraCollateralAPY extends Omit<Apy, "protocol"> {
+  pool: Address;
+  type: "relative" | "absolute";
+}
+
+export type TokenExtraCollateralAPYResult = Record<
+  Address,
+  Array<ExtraCollateralAPY>
+>;
+export type TokenExtraCollateralAPYHandler = (
+  network: NetworkType,
+) => Promise<TokenExtraCollateralAPYResult>;
+
+export const EXTRA_APY: Record<NetworkType, Array<ExtraCollateralAPY>> = {
+  Mainnet: [
+    {
+      pool: "0xff94993fa7ea27efc943645f95adb36c1b81244b", // WSTETH_POOL
+      address: "0x7a4EffD87C2f3C55CA251080b1343b605f327E3a", // RSTETH
+      symbol: "rstETH",
+      value: 1,
+      type: "relative",
+    },
+  ],
+  Optimism: [],
+  Arbitrum: [],
+  Base: [],
+  Sonic: [],
+};

--- a/src/tokenExtraCollateralAPY/index.ts
+++ b/src/tokenExtraCollateralAPY/index.ts
@@ -1,0 +1,2 @@
+export * from "./constants";
+export * from "./rewards";

--- a/src/tokenExtraCollateralAPY/rewards.ts
+++ b/src/tokenExtraCollateralAPY/rewards.ts
@@ -1,0 +1,26 @@
+import type { Address } from "viem";
+
+import type {
+  TokenExtraCollateralAPYHandler,
+  TokenExtraCollateralAPYResult,
+} from "./constants";
+import { EXTRA_APY } from "./constants";
+
+// allows rewrite base apy of a token for a pool in absolute or relative manner
+const getTokenExtraCollateralAPY: TokenExtraCollateralAPYHandler =
+  async network => {
+    const rewards = EXTRA_APY[network];
+
+    const result = rewards.reduce<TokenExtraCollateralAPYResult>((acc, p) => {
+      const address = p.address.toLowerCase() as Address;
+      const pool = p.pool.toLowerCase() as Address;
+
+      acc[address] = [...(acc[address] || []), { ...p, address, pool }];
+
+      return acc;
+    }, {});
+
+    return result;
+  };
+
+export { getTokenExtraCollateralAPY };

--- a/src/tokenExtraCollateralPoints/constants.ts
+++ b/src/tokenExtraCollateralPoints/constants.ts
@@ -1,0 +1,38 @@
+import type { Address } from "viem";
+
+import type { PointsInfo } from "../points";
+import { REWARDS_BASE_INFO } from "../points";
+import type { NetworkType } from "../utils";
+
+export type TokenExtraCollateralPointsResult = Record<
+  Address,
+  ExtraCollateralPointsInfo
+>;
+export type ExtraCollateralPointsHandler = (
+  network: NetworkType,
+) => Promise<TokenExtraCollateralPointsResult>;
+
+export interface ExtraCollateralPointsInfo extends PointsInfo {
+  pool: Address;
+}
+
+export const POINTS_INFO_BY_NETWORK: Record<
+  NetworkType,
+  Array<ExtraCollateralPointsInfo>
+> = {
+  Mainnet: [
+    {
+      pool: "0xff94993fa7ea27efc943645f95adb36c1b81244b",
+      address: "0x7a4EffD87C2f3C55CA251080b1343b605f327E3a",
+      symbol: "rstETH",
+      rewards: [
+        REWARDS_BASE_INFO.symbiotic(35n),
+        REWARDS_BASE_INFO.mellow(70n),
+      ],
+    },
+  ],
+  Arbitrum: [],
+  Optimism: [],
+  Base: [],
+  Sonic: [],
+};

--- a/src/tokenExtraCollateralPoints/index.ts
+++ b/src/tokenExtraCollateralPoints/index.ts
@@ -1,0 +1,2 @@
+export * from "./constants";
+export * from "./rewards";

--- a/src/tokenExtraCollateralPoints/rewards.ts
+++ b/src/tokenExtraCollateralPoints/rewards.ts
@@ -1,0 +1,37 @@
+import type { Address } from "viem";
+
+import type {
+  ExtraCollateralPointsHandler,
+  TokenExtraCollateralPointsResult,
+} from "./constants";
+import { POINTS_INFO_BY_NETWORK } from "./constants";
+
+const getTokenExtraCollateralPoints: ExtraCollateralPointsHandler =
+  async network => {
+    const points = POINTS_INFO_BY_NETWORK[network];
+
+    const result = points.reduce<TokenExtraCollateralPointsResult>((acc, p) => {
+      const address = p.address.toLowerCase() as Address;
+      const pool = p.pool.toLowerCase() as Address;
+
+      acc[address] = {
+        ...p,
+        address,
+        pool,
+        ...(p.debtRewards
+          ? {
+              debtRewards: p.debtRewards.map(r => ({
+                ...r,
+                cm: r.cm.toLowerCase() as Address,
+              })),
+            }
+          : {}),
+      };
+
+      return acc;
+    }, {});
+
+    return result;
+  };
+
+export { getTokenExtraCollateralPoints };

--- a/src/tokenExtraRewards/constants.ts
+++ b/src/tokenExtraRewards/constants.ts
@@ -8,7 +8,7 @@ export type TokenExtraRewardsHandler = (
 ) => Promise<TokenExtraRewardsResult>;
 
 export interface FarmInfo {
-  token: Address;
+  address: Address;
   symbol: string;
 
   rewardToken: Address;

--- a/src/tokenExtraRewards/rewards.ts
+++ b/src/tokenExtraRewards/rewards.ts
@@ -6,14 +6,15 @@ import type {
 } from "./constants";
 import { EXTRA_REWARDS_INFO } from "./constants";
 
+// extra apy on top of base apy
 const getTokenExtraRewards: TokenExtraRewardsHandler = async network => {
   const rewards = EXTRA_REWARDS_INFO[network];
 
   const result = rewards.reduce<TokenExtraRewardsResult>((acc, p) => {
-    const token = p.token.toLowerCase() as Address;
+    const address = p.address.toLowerCase() as Address;
     const rewardToken = p.rewardToken.toLowerCase() as Address;
 
-    acc[token] = [...(acc[token] || []), { ...p, token, rewardToken }];
+    acc[address] = [...(acc[address] || []), { ...p, address, rewardToken }];
 
     return acc;
   }, {});


### PR DESCRIPTION
This pull request includes changes to standardize the attribute names in the APY-related code and to enhance the endpoints by including additional collateral data. The most important changes include renaming the `reward` attribute to `address` across various files, updating the `endpoints.ts` file to handle new collateral data, and modifying the `fetcher.ts` file to fetch and process this additional data.

Standardization of attribute names:

* `src/apy/coinshift/apy.ts`, `src/apy/constant/apy.ts`, `src/apy/curve/apy.ts`, `src/apy/ethena/apy.ts`, `src/apy/lido/apy.ts`, `src/apy/llama/apy.ts`, `src/apy/sky/apy.ts`, `src/apy/sonic/apy.ts`, `src/apy/treehouse/apy.ts`, `src/apy/yearn/apy.ts`: Renamed the `reward` attribute to `address` in the `apys` array. [[1]](diffhunk://#diff-c7412c4cd78b795f053da1ff17808a6b016943c6a94af073a79b4b0854df9923L46-R46) [[2]](diffhunk://#diff-d096abc12d65a6ae5428ea19648a6d1621d8a56333e4acf46ab6fb0c4748a2eaL18-R18) [[3]](diffhunk://#diff-58a1aee5f9b11c6c85061b0a277276a78b85aae4a1c905d02959e290001bed6dL149-R149) [[4]](diffhunk://#diff-e949ef3288d41233397a7c62f937ccd2544a754696b764a63090ecaeb43d9657L30-R30) [[5]](diffhunk://#diff-8756f7b30481ee36dc6a033a5ae52e843bd475f57aca4f295827036ffdd97442L44-R44) [[6]](diffhunk://#diff-e79e299053c0262c736515bc2f2ae3e005fcf3fc770a274102033a6503833ea8L46-R46) [[7]](diffhunk://#diff-2e07b103c2da64732bf5e472d5d65a28c35d4d3b3f962cbcb972d205b4a8c287L32-R32) [[8]](diffhunk://#diff-be6c225b28bc8d39c0e1873cafcea6cf65013b99be0c877a1ec22f6ef8c316ffL30-R30) [[9]](diffhunk://#diff-5f5d1ec77418ce1d266681aeac955d0c80ecb89df4bbcc2884e23ebf84e4d207L29-R29) [[10]](diffhunk://#diff-a41e6ceec8ea2c5d194e8b2e8b6992b0801f751f1e02c2eca0bc88901171b91aL44-R44)

Enhancements to endpoints:

* [`src/endpoints.ts`](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R8-R9): Added handling for `extraCollateralAPY` and `extraCollateralPoints` by including these attributes in the `TokenOutputDetails` interface and updating the `getByChainAndToken`, `getAll`, and `getRewardList` functions to process these new attributes. [[1]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R8-R9) [[2]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L16-R24) [[3]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R48-R53) [[4]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R70-R88) [[5]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R105-R116) [[6]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R126-R140) [[7]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R150-R180) [[8]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R254-R274)

Updates to fetcher:

* [`src/fetcher.ts`](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0L1): Imported new types and functions for fetching extra collateral data, updated the `NetworkState` interface to include `tokenExtraCollateralAPY` and `tokenExtraCollateralPoints`, and modified the `getNetworkState` method to fetch and log this additional data. [[1]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0L1) [[2]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0R22-R25) [[3]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0R36-L125) [[4]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0L134-R63) [[5]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0R72-R75) [[6]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0L155-R98) [[7]](diffhunk://#diff-eb275dd515bd68f45e5e14b12d3f4ff97dc9b1e52d742f0e66f56f67dccb21b0L166-R112)