### PR TITLE
feat: better sentry reporting

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,17 +1,19 @@
+import { init } from "@sentry/node";
 import cors from "cors";
 import { config } from "dotenv";
 import express, { json } from "express";
 
 import { Fetcher } from "./src/fetcher";
-config();
 
-import { captureException, init } from "@sentry/node";
+config();
 
 init({
   dsn: "https://068cd79b8537ac37326fd7e917c0df41@o4509052850470912.ingest.us.sentry.io/4509052850733057",
 
   // Set sampling rate for profiling - this is evaluated only once per SDK.init
   profileSessionSampleRate: 1.0,
+  enabled: true,
+  normalizeDepth: 10,
 });
 
 import {
@@ -22,6 +24,7 @@ import {
   getPoolRewards,
   getRewardList,
 } from "./src/endpoints";
+import { captureException } from "./src/sentry";
 
 const app = express();
 const port = process.env.PORT ?? 8000;
@@ -41,26 +44,49 @@ void (async function run() {
 })();
 
 app.get("/api/health", (req, res) => {
-  res.sendStatus(200);
+  try {
+    res.sendStatus(200);
+  } catch (e) {
+    captureException({ file: "/api/health", error: e });
+  }
 });
 app.get("/api/rewards/gear-apy", (req, res) => {
-  void getGearAPY(req, res, f);
+  try {
+    void getGearAPY(req, res, f);
+  } catch (e) {
+    captureException({ file: "/api/rewards/gear-apy", error: e });
+  }
 });
 app.get("/api/rewards/pools/all", (req, res) => {
-  void getPoolRewards(req, res, f);
+  try {
+    void getPoolRewards(req, res, f);
+  } catch (e) {
+    captureException({ file: "/api/rewards/pools/all", error: e });
+  }
 });
 app.get("/api/rewards/tokens/all", (req, res) => {
-  void getAll(req, res, f);
+  try {
+    void getAll(req, res, f);
+  } catch (e) {
+    captureException({ file: "/api/rewards/tokens/all", error: e });
+  }
 });
 app.post("/api/rewards/tokens/list", (req, res) => {
-  void getRewardList(req, res, f);
-});
-// !& backwards compatibility
-app.get("/api/rewards/all/", (req, res) => {
-  void getAll(req, res, f);
+  try {
+    void getRewardList(req, res, f);
+  } catch (e) {
+    captureException({ file: "/api/rewards/tokens/list", error: e });
+  }
 });
 app.get("/api/rewards/tokens/:chainId/:tokenAddress", (req, res) => {
-  void getByChainAndToken(req, res, f);
+  try {
+    void getByChainAndToken(req, res, f);
+  } catch (e) {
+    captureException({
+      file: "/api/rewards/tokens/:chainId/:tokenAddress",
+      error: e,
+    });
+  }
 });
 
 app.get("/api/rewards/list", (req, res) => {
@@ -78,5 +104,5 @@ try {
     console.log(`[server]: Server is running at http://localhost:${port}`);
   });
 } catch (e) {
-  captureException(e);
+  captureException({ file: "main/app.listen", error: e });
 }

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -1,3 +1,4 @@
+import { captureException } from "@sentry/node";
 import type { Address } from "viem";
 import { isAddress } from "viem";
 
@@ -51,7 +52,7 @@ function removeSymbolAndAddress<T extends { address: Address; symbol: string }>(
   return l.map(({ symbol, address, ...rest }) => rest);
 }
 
-export async function getByChainAndToken(req: any, res: any, fetcher: Fetcher) {
+export function getByChainAndToken(req: any, res: any, fetcher: Fetcher) {
   const [isChainIdValid, chainId] = checkChainId(req.params.chainId);
   if (!checkResp(isChainIdValid, res)) {
     return;
@@ -93,7 +94,7 @@ export async function getByChainAndToken(req: any, res: any, fetcher: Fetcher) {
   res.send(toJSONWithBigint({ data: data, status: "ok" } as Response));
 }
 
-export async function getAll(req: any, res: any, fetcher: Fetcher) {
+export function getAll(req: any, res: any, fetcher: Fetcher) {
   const [isChainIdValid, chainId] = checkChainId(req.query.chain_id);
   if (!checkResp(isChainIdValid, res)) {
     return;
@@ -226,7 +227,7 @@ export async function getAll(req: any, res: any, fetcher: Fetcher) {
   );
 }
 
-export async function getRewardList(req: any, res: any, fetcher: Fetcher) {
+export function getRewardList(req: any, res: any, fetcher: Fetcher) {
   if (req.header("Content-Type") !== "application/json") {
     checkResp(
       {
@@ -280,7 +281,7 @@ export async function getRewardList(req: any, res: any, fetcher: Fetcher) {
   res.send(toJSONWithBigint({ data: data, status: "ok" } as Response));
 }
 
-export async function getGearAPY(req: any, res: any, fetcher: Fetcher) {
+export function getGearAPY(req: any, res: any, fetcher: Fetcher) {
   const [isChainIdValid, chainId] = checkChainId(req.query.chain_id);
   if (!checkResp(isChainIdValid, res)) {
     return;
@@ -295,7 +296,7 @@ export async function getGearAPY(req: any, res: any, fetcher: Fetcher) {
   );
 }
 
-export async function getPoolRewards(req: any, res: any, fetcher: Fetcher) {
+export function getPoolRewards(req: any, res: any, fetcher: Fetcher) {
   const [isChainIdValid, chainId] = checkChainId(req.query.chain_id);
   if (!checkResp(isChainIdValid, res)) {
     return;
@@ -368,8 +369,10 @@ function checkTokenAddress(data: any): [Response, string] {
 
 export function checkResp(res: Response, out: any): boolean {
   if (res.status === "error") {
+    const r = toJSONWithBigint(res);
     out.set({ "Content-Type": "application/json" });
-    out.send(toJSONWithBigint(res));
+    out.send(toJSONWithBigint(r));
+    captureException({ file: "endpoints/checkResp", error: r });
     return false;
   }
   return true;

--- a/src/sentry/index.ts
+++ b/src/sentry/index.ts
@@ -1,0 +1,20 @@
+import * as Sentry from "@sentry/node";
+
+interface SentryError {
+  file: string;
+  error: unknown;
+}
+
+export const APP_NAME_TAG = "app.name";
+export const APP_PATH_TAG = "app.path";
+export const ERR_DESCRIPTION_TAG = "err.description";
+export const APP_NAME = "gearbox_apy_server";
+
+export function captureException({ file, error: e }: SentryError) {
+  Sentry.withScope(scope => {
+    scope.setTag(APP_NAME_TAG, APP_NAME);
+    scope.setTag(APP_PATH_TAG, file);
+
+    Sentry.captureException(e);
+  });
+}


### PR DESCRIPTION
This pull request introduces several improvements to error handling and refactors some asynchronous functions to be synchronous in the `main.ts` and `src/endpoints.ts` files. The most important changes include adding centralized error capturing using Sentry, modifying API endpoint functions to handle errors, and refactoring functions to be synchronous.

### Error Handling Improvements:
* [`main.ts`](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R27): Introduced `captureException` from `src/sentry` to handle exceptions in API endpoints and the main application. Added try-catch blocks around API routes to capture and log errors. [[1]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R27) [[2]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0R47-R89) [[3]](diffhunk://#diff-564c860307257bfac9176f554a35aa858c350a59d75c0dcd0a5d63a480805bd0L81-R107)
* [`src/endpoints.ts`](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44R372-R375): Added `captureException` to log errors when responses indicate an error status.
* [`src/sentry/index.ts`](diffhunk://#diff-c0aa1754d4f86ff6744bc9099caede13982c9261ff54b3ae45b5676cdb68d01dR1-R20): Created a new Sentry utility module to standardize error capturing with additional tags for better traceability.

### Function Refactoring:
* [`src/endpoints.ts`](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L54-R55): Refactored several functions (`getByChainAndToken`, `getAll`, `getRewardList`, `getGearAPY`, `getPoolRewards`) to be synchronous instead of asynchronous. [[1]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L54-R55) [[2]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L96-R97) [[3]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L229-R230) [[4]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L283-R284) [[5]](diffhunk://#diff-db66f462d76a03de8f53d993fa381b0034bdbf5e74539f4abccfc636a93c2f44L298-R299)